### PR TITLE
[WIP] Custom nginx server setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.pem
 conf/nginx.conf
 certs/*.pem
 certs/*.key

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 conf/nginx.conf
+certs/*.pem
+certs/*.key

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 conf/nginx.conf
 certs/*.pem
 certs/*.key
+certs/*.crt

--- a/bin/server
+++ b/bin/server
@@ -1,2 +1,2 @@
-PORT=9000 ruby -rerb -e "puts ERB.new(File.read('conf/nginx.conf.erb')).result" > $(pwd)/conf/nginx.conf
+ruby -rerb -e "puts ERB.new(File.read('conf/nginx.conf.erb')).result" > $(pwd)/conf/nginx.conf
 nginx -c $(pwd)/conf/nginx.conf

--- a/certs/readme.md
+++ b/certs/readme.md
@@ -1,0 +1,3 @@
+# Certs
+
+Add your certificates here to be uploaded into the instance.

--- a/conf/nginx.conf.erb
+++ b/conf/nginx.conf.erb
@@ -1,27 +1,36 @@
-server {
-    listen 80;
+worker_processes 4;
 
-    # SSL Configuration
-    listen 443;
-    ssl    on;
-    ssl_certificate    /etc/ssl/domain.pem;
-    ssl_certificate_key    /etc/ssl/domain.key;
+events {
+    worker_connections 1024;
+}
 
-    <% (19000..20000).each do |unsubscribe_port| %>
-      listen <%= unsubscribe_port %>;
-    <% end %>
+http {
+  server_tokens off;
+  client_body_timeout 5;
+  server {
+      listen 80 default_server;
 
-    proxy_ssl_session_reuse off;
+      # SSL Configuration
+      listen 443 ssl;
+      ssl_certificate    /etc/ssl/domain.pem;
+      ssl_certificate_key    /etc/ssl/domain.key;
 
-    location /apple-app-site-association {
-        proxy_pass <%= ENV['APP_ASSOCIATION_HOST'] || "https://www.everlane.com" %>;
-    }
+      <% (19000..20000).each do |unsubscribe_port| %>
+        listen <%= unsubscribe_port %>;
+      <% end %>
 
-    location = / {
-        proxy_pass <%= ENV['APP_ASSOCIATION_HOST'] || "https://www.everlane.com" %>;
-    }
+      proxy_ssl_session_reuse off;
 
-    location / {
-        proxy_pass http://cb.sailthru.com;
-    }
+      location /apple-app-site-association {
+          proxy_pass <%= ENV['APP_ASSOCIATION_HOST'] || "https://www.everlane.com" %>;
+      }
+
+      location = / {
+          proxy_pass <%= ENV['APP_ASSOCIATION_HOST'] || "https://www.everlane.com" %>;
+      }
+
+      location / {
+          proxy_pass http://cb.sailthru.com;
+      }
+  }
 }

--- a/conf/nginx.conf.erb
+++ b/conf/nginx.conf.erb
@@ -15,14 +15,14 @@ http {
       ssl_certificate    /etc/ssl/domain.pem;
       ssl_certificate_key    /etc/ssl/domain.key;
 
-      <% (19000..20000).each do |unsubscribe_port| %>
-        listen <%= unsubscribe_port %>;
-      <% end %>
-
       proxy_ssl_session_reuse off;
 
       location /apple-app-site-association {
           proxy_pass <%= ENV['APP_ASSOCIATION_HOST'] || "https://www.everlane.com" %>;
+      }
+
+      location /oc {
+        rewrite ^(.*) http://cb.sailthru.com$1 permanent;
       }
 
       location = / {
@@ -32,5 +32,6 @@ http {
       location / {
           proxy_pass http://cb.sailthru.com;
       }
+
   }
 }

--- a/conf/nginx.conf.erb
+++ b/conf/nginx.conf.erb
@@ -12,20 +12,18 @@ http {
 
   server {
       listen <%= ENV['PORT'] %> ssl;
+      proxy_ssl_session_reuse off;
 
       location /apple-app-site-association {
           proxy_pass <%= ENV['APP_ASSOCIATION_HOST'] %>;
-          proxy_ssl_session_reuse on;
       }
 
       location = / {
           proxy_pass <%= ENV['APP_ASSOCIATION_HOST'] %>;
-          proxy_ssl_session_reuse on;
       }
 
       location / {
           proxy_pass http://cb.sailthru.com;
-          proxy_ssl_session_reuse off;
       }
   }
 }

--- a/conf/nginx.conf.erb
+++ b/conf/nginx.conf.erb
@@ -15,6 +15,7 @@ http {
 
       location /apple-app-site-association {
           proxy_pass <%= ENV['APP_ASSOCIATION_HOST'] %>;
+          proxy_ssl_session_reuse on;
       }
 
       location / {

--- a/conf/nginx.conf.erb
+++ b/conf/nginx.conf.erb
@@ -11,7 +11,7 @@ http {
 	client_body_timeout 5;
 
   server {
-      listen <%= ENV['PORT'] %> ssl;
+      listen <%= ENV['PORT'] %>;
       proxy_ssl_session_reuse off;
 
       location /apple-app-site-association {

--- a/conf/nginx.conf.erb
+++ b/conf/nginx.conf.erb
@@ -18,6 +18,11 @@ http {
           proxy_ssl_session_reuse on;
       }
 
+      location = / {
+          proxy_pass <%= ENV['APP_ASSOCIATION_HOST'] %>;
+          proxy_ssl_session_reuse on;
+      }
+
       location / {
           proxy_pass http://cb.sailthru.com;
           proxy_ssl_session_reuse off;

--- a/conf/nginx.conf.erb
+++ b/conf/nginx.conf.erb
@@ -11,7 +11,13 @@ http {
 	client_body_timeout 5;
 
   server {
-      listen <%= ENV['PORT'] %>;
+      listen 80;
+      listen 443;
+
+      <% (19000..20000).each do |unsubscribe_port| %>
+        listen <%= unsubscribe_port %>;
+      <% end %>
+
       proxy_ssl_session_reuse off;
 
       location /apple-app-site-association {

--- a/conf/nginx.conf.erb
+++ b/conf/nginx.conf.erb
@@ -12,7 +12,12 @@ http {
 
   server {
       listen 80;
+
+      # SSL Configuration
       listen 443;
+      ssl    on;
+      ssl_certificate    /etc/ssl/your_domain_name.pem;
+      ssl_certificate_key    /etc/ssl/your_domain_name.key;
 
       <% (19000..20000).each do |unsubscribe_port| %>
         listen <%= unsubscribe_port %>;

--- a/conf/nginx.conf.erb
+++ b/conf/nginx.conf.erb
@@ -14,11 +14,12 @@ http {
       listen <%= ENV['PORT'] %>;
 
       location /apple-app-site-association {
-      proxy_pass <%= ENV['APP_ASSOCIATION_HOST'] %>;
+          proxy_pass <%= ENV['APP_ASSOCIATION_HOST'] %>;
       }
 
       location / {
           proxy_pass http://cb.sailthru.com;
+          proxy_ssl_session_reuse off;
       }
   }
 }

--- a/conf/nginx.conf.erb
+++ b/conf/nginx.conf.erb
@@ -1,40 +1,27 @@
-daemon off;
-worker_processes 4;
+server {
+    listen 80;
 
-events {
-	worker_connections 1024;
-}
+    # SSL Configuration
+    listen 443;
+    ssl    on;
+    ssl_certificate    /etc/ssl/domain.pem;
+    ssl_certificate_key    /etc/ssl/domain.key;
 
-http {
-  server_tokens off;
+    <% (19000..20000).each do |unsubscribe_port| %>
+      listen <%= unsubscribe_port %>;
+    <% end %>
 
-	client_body_timeout 5;
+    proxy_ssl_session_reuse off;
 
-  server {
-      listen 80;
+    location /apple-app-site-association {
+        proxy_pass <%= ENV['APP_ASSOCIATION_HOST'] || "https://www.everlane.com" %>;
+    }
 
-      # SSL Configuration
-      listen 443;
-      ssl    on;
-      ssl_certificate    /etc/ssl/your_domain_name.pem;
-      ssl_certificate_key    /etc/ssl/your_domain_name.key;
+    location = / {
+        proxy_pass <%= ENV['APP_ASSOCIATION_HOST'] || "https://www.everlane.com" %>;
+    }
 
-      <% (19000..20000).each do |unsubscribe_port| %>
-        listen <%= unsubscribe_port %>;
-      <% end %>
-
-      proxy_ssl_session_reuse off;
-
-      location /apple-app-site-association {
-          proxy_pass <%= ENV['APP_ASSOCIATION_HOST'] %>;
-      }
-
-      location = / {
-          proxy_pass <%= ENV['APP_ASSOCIATION_HOST'] %>;
-      }
-
-      location / {
-          proxy_pass http://cb.sailthru.com;
-      }
-  }
+    location / {
+        proxy_pass http://cb.sailthru.com;
+    }
 }

--- a/conf/nginx.conf.erb
+++ b/conf/nginx.conf.erb
@@ -11,7 +11,7 @@ http {
 	client_body_timeout 5;
 
   server {
-      listen <%= ENV['PORT'] %>;
+      listen <%= ENV['PORT'] %> ssl;
 
       location /apple-app-site-association {
           proxy_pass <%= ENV['APP_ASSOCIATION_HOST'] %>;

--- a/deploy/server-setup.sh
+++ b/deploy/server-setup.sh
@@ -16,5 +16,17 @@ echo "packer: nginx - installing as a service"
 sudo update-rc.d nginx defaults
 
 echo "packer: nginx - Installing config"
+sudo mkdir -p /etc/nginx/
+sudo mv /tmp/nginx.conf /etc/nginx/sites-enabled
+#sudo chown $INSTANCE_USER /etc/nginx/
+#sudo chmod -r 755 /etc/nginx/
 
 echo "packer: nginx - Install SSL Certificate"
+sudo mkdir -p /etc/ssl/
+sudo mv /tmp/domain.key /etc/ssl/
+sudo mv /tmp/domain.pem /etc/ssl/
+#sudo chown $INSTANCE_USER /etc/ssl/
+#sudo chmod -r 755 /etc/ssl/
+
+echo "packer: reload nginx"
+sudo service nginx reload

--- a/deploy/server-setup.sh
+++ b/deploy/server-setup.sh
@@ -14,3 +14,7 @@ sudo apt-get install nginx -y
 
 echo "packer: nginx - installing as a service"
 sudo update-rc.d nginx defaults
+
+echo "packer: nginx - Installing config"
+
+echo "packer: nginx - Install SSL Certificate"

--- a/deploy/server-setup.sh
+++ b/deploy/server-setup.sh
@@ -17,16 +17,12 @@ sudo update-rc.d nginx defaults
 
 echo "packer: nginx - Installing config"
 sudo mkdir -p /etc/nginx/
-sudo mv /tmp/nginx.conf /etc/nginx/sites-enabled
-#sudo chown $INSTANCE_USER /etc/nginx/
-#sudo chmod -r 755 /etc/nginx/
+sudo mv /tmp/nginx.conf /etc/nginx/nginx.conf
 
 echo "packer: nginx - Install SSL Certificate"
 sudo mkdir -p /etc/ssl/
 sudo mv /tmp/domain.key /etc/ssl/
 sudo mv /tmp/domain.pem /etc/ssl/
-#sudo chown $INSTANCE_USER /etc/ssl/
-#sudo chmod -r 755 /etc/ssl/
 
 echo "packer: reload nginx"
 sudo service nginx reload

--- a/deploy/server-setup.sh
+++ b/deploy/server-setup.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+echo "packer: updating aptitude"
+sudo apt-key update
+sudo apt-get update
+sudo apt-get remove apt-listchanges -y
+sudo add-apt-repository ppa:nginx/stable -y
+
+echo "packer: nginx - base install"
+sudo mkdir -p /var/log/nginx
+sudo chown $INSTANCE_USER /var/log/nginx
+sudo chmod -R 755 /var/log/nginx
+sudo apt-get install nginx -y
+
+echo "packer: nginx - installing as a service"
+sudo update-rc.d nginx defaults

--- a/packer.json
+++ b/packer.json
@@ -15,6 +15,15 @@
   }],
   "provisioners": [
     {
+      "type": "shell-local",
+      "command": "ruby -rerb -e \"puts ERB.new(File.read('conf/nginx.conf.erb')).result\" > $(pwd)/conf/nginx.conf nginx -c $(pwd)/conf/nginx.conf"
+    },
+    {
+      "type": "file",
+      "source": "conf/nginx.conf",
+      "destination": "/tmp/nginx.conf"
+    },
+    {
       "type": "file",
       "source": "certs/domain.key",
       "destination": "/tmp/domain.key"

--- a/packer.json
+++ b/packer.json
@@ -11,7 +11,7 @@
     "source_ami": "ami-fb6c1d91",
     "instance_type": "t1.micro",
     "ssh_username": "ubuntu",
-    "ami_name": "packer-example {{timestamp}}"
+    "ami_name": "Sailthru-Proxy {{timestamp}}"
   }],
   "provisioners": [
     {

--- a/packer.json
+++ b/packer.json
@@ -1,0 +1,20 @@
+{
+  "variables": {
+    "aws_access_key": "",
+    "aws_secret_key": ""
+  },
+  "builders": [{
+    "type": "amazon-ebs",
+    "access_key": "{{user `aws_access_key`}}",
+    "secret_key": "{{user `aws_secret_key`}}",
+    "region": "us-east-1",
+    "source_ami": "ami-de0d9eb7",
+    "instance_type": "t1.micro",
+    "ssh_username": "ubuntu",
+    "ami_name": "packer-example {{timestamp}}"
+  }],
+  "provisioners": [{
+    "type": "shell",
+    "script": "deploy/server-setup.sh"
+  }]
+}

--- a/packer.json
+++ b/packer.json
@@ -13,8 +13,19 @@
     "ssh_username": "ubuntu",
     "ami_name": "packer-example {{timestamp}}"
   }],
-  "provisioners": [{
-    "type": "shell",
-    "script": "deploy/server-setup.sh"
-  }]
+  "provisioners": [
+    {
+      "type": "file",
+      "source": "certs/domain.key",
+      "destination": "/tmp/domain.key"
+    },
+    {
+      "type": "file",
+      "source": "certs/domain.pem",
+      "destination": "/tmp/domain.pem"
+    },
+    {
+      "type": "shell",
+      "script": "deploy/server-setup.sh"
+    }]
 }

--- a/packer.json
+++ b/packer.json
@@ -8,7 +8,7 @@
     "access_key": "{{user `aws_access_key`}}",
     "secret_key": "{{user `aws_secret_key`}}",
     "region": "us-east-1",
-    "source_ami": "ami-de0d9eb7",
+    "source_ami": "ami-fb6c1d91",
     "instance_type": "t1.micro",
     "ssh_username": "ubuntu",
     "ami_name": "packer-example {{timestamp}}"


### PR DESCRIPTION
After launching this proxy on heroku we had two problems:
- SSL was not being proxied properly
- Sailthru uses ports other than 80 and 443 to handle unsubscribes

Heroku, while wonderful for hosting things that live on port 80 and 443 does not handle servers that need to open (literally) 1000 ports.  The issues with SSL appear like they may have been related to the way heroku handles their routing.  This PR addresses these issues by moving this off of heroku and onto AWS.
## Introducing Packer

[Packer](http://packer.io) is a tool for building machine images.  Here we use to it to build an Amazon AMI.

To use this PR you'll first need to install packer (`brew install packer`)

After that you'll need to place the SSL certs into the `certs/` folder.

Finally run `packer packer.json`
